### PR TITLE
Use PSR-4 autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         "doctrine/dbal": "~2.3"
     },
     "autoload": {
-        "psr-0": {
-            "Mpociot\\LaravelTestFactoryHelper": "src/"
+        "psr-4": {
+            "Mpociot\\LaravelTestFactoryHelper\\": "src/"
         }
     }
 }


### PR DESCRIPTION
Was trying this out and as seen in issue #1, I could not install successfully without receiving:

```
[Symfony\Component\Debug\Exception\FatalErrorException]

Class 'Mpociot\LaravelTestFactoryHelper\TestFactoryHelperServiceProvider' not found
```

Here's what I did to get it working for me.

- Changed autoloading to PSR-4.
- Temporarily removed `Mpociot\LaravelTestFactoryHelper\TestFactoryHelperServiceProvider` from `config/app.php`

- `composer dumpauto -o`
- `php artisan optimize && php artisan clear-compiled`
- Added `Mpociot\LaravelTestFactoryHelper\TestFactoryHelperServiceProvider` back to `config/app.php`

Now it's working for me.

P.s
You have some great ideas for testing tools in Laravel, please keep them coming...