### PR TITLE
Support for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,12 @@
         "psr-4": {
             "Mpociot\\LaravelTestFactoryHelper\\": "src/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Mpociot\\LaravelTestFactoryHelper\\TestFactoryHelperServiceProvider"
+            ]
+        }
     }
 }

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -81,7 +81,7 @@ class GenerateCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $filename = $this->option('filename');
         $this->dirs = $this->option('dir');


### PR DESCRIPTION
Support for Laravel 5.5

- Changed deprecated `fire` method to `handle` method
- Added support for package auto-discovery