### PR TITLE
Update and streamline package for common use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $factory->define(App\User::class, function (Faker\Generator $faker) {
         'email' => $faker->safeEmail,
         'password' => bcrypt($faker->password),
         'company_id' => factory(App\Company::class)->create()->id,
-        'remember_token' => str_random(10),
+        'remember_token' => Str::random(10),
     ];
 });
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Laravel Test Factory Generator
 
-`php artisan test-factory-helper:generate`
+`php artisan generate:model-factory`
 
 This package helps you generate model factories from your existing models / database structure to get started with testing your Laravel application even faster.
 
@@ -60,7 +60,7 @@ Mpociot\LaravelTestFactoryHelper\TestFactoryHelperServiceProvider::class
 
 Just call the artisan command:
 
-`php artisan test-factory-helper:generate`
+`php artisan generate:model-factory`
 
 This command will look for all models in your "app" folder (configurable by using the `--dir` option) and create test factories and save them in your `database/factories/ModelFactory.php`.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `php artisan generate:model-factory`
 
-This package helps you generate model factories from your existing models / database structure to get started with testing your Laravel application even faster.
+This package will generate [factories](https://laravel.com/docs/master/database-testing#writing-factories) from your existing models so you can get started with testing your Laravel application more quickly.
 
 ### Example output
 
@@ -48,25 +48,24 @@ $factory->define(App\User::class, function (Faker\Generator $faker) {
 Require this package with composer using the following command:
 
 ```bash
-composer require mpociot/laravel-test-factory-helper
-```
-Go to your `config/app.php` and add the service provider:
-
-```php
-Mpociot\LaravelTestFactoryHelper\TestFactoryHelperServiceProvider::class
+composer require --dev mpociot/laravel-test-factory-helper
 ```
 
 ### Usage
 
-Just call the artisan command:
+To generate multiple factories at once, run the artisan command:
 
 `php artisan generate:model-factory`
 
-This command will look for all models in your "app" folder (configurable by using the `--dir` option) and create test factories and save them in your `database/factories/ModelFactory.php`.
+This command will find all models within your application and create test factories. By default, this will not overwrite any existing model factories. You can _force_ overwriting existing model factories by using the `--force` option.
 
-The output filename is also configurable by using the `--filename` option.
+To generate a factory for specific model or models, run the artisan command:
 
-By default, the command will only append new models and doesn't modify the existing content of your factories file. To rewrite the file, use the `--reset` option.
+`php artisan generate:model-factory User Team`
+
+By default, this command will search under the `app` folder for models. If your models are within a different folder, for example `app/Models`, you can specify this using `--dir` option. In this case, run the artisan command:
+
+`php artisan generate:model-factory --dir app/Models -- User Team`
 
 ### License
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
         "illuminate/support": "^5.5",
         "illuminate/console": "^5.5",
         "illuminate/filesystem": "^5.5",
-        "symfony/class-loader": "~3.3",
         "doctrine/dbal": "~2.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "keywords": ["Laravel", "Tests", "Factory"],
     "license": "MIT",
     "require": {
-        "php": ">=5.6.0",
-        "illuminate/support": "^5.0",
-        "illuminate/console": "^5.0",
-        "illuminate/filesystem": "^5.0",
-        "symfony/class-loader": "^2.3|3.*",
+        "php": ">=7.0",
+        "illuminate/support": "^5.5",
+        "illuminate/console": "^5.5",
+        "illuminate/filesystem": "^5.5",
+        "symfony/class-loader": "~3.3",
         "doctrine/dbal": "~2.3"
     },
     "autoload": {

--- a/resources/views/factory.blade.php
+++ b/resources/views/factory.blade.php
@@ -1,9 +1,11 @@
+/* @@var $factory \Illuminate\Database\Eloquent\Factory */
 
-$factory->define({{$reflection->getName()}}::class, function (Faker\Generator $faker) {
+use Faker\Generator as Faker;
+
+$factory->define({{ $reflection->getName() }}::class, function (Faker $faker) {
     return [
-@foreach($properties as $name => $property)
-        '{{$name}}' => @if($property['faker']){!!$property['type']!!}@else'{{$property['type']}}'@endif,
-@endforeach
+    @foreach($properties as $name => $property)
+        '{{$name}}' => {!! $property !!},
+    @endforeach
     ];
 });
-

--- a/resources/views/factory.blade.php
+++ b/resources/views/factory.blade.php
@@ -4,8 +4,8 @@ use Faker\Generator as Faker;
 
 $factory->define({{ $reflection->getName() }}::class, function (Faker $faker) {
     return [
-    @foreach($properties as $name => $property)
+@foreach($properties as $name => $property)
         '{{$name}}' => {!! $property !!},
-    @endforeach
+@endforeach
     ];
 });

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -37,7 +37,7 @@ class GenerateCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Generate test factories for models';
+    protected $description = 'Generate database test factories for models';
 
     /**
      * @var string
@@ -48,11 +48,6 @@ class GenerateCommand extends Command
      * @var array
      */
     protected $properties = array();
-
-    /**
-     * @var array
-     */
-    protected $dirs = array();
 
     /**
      * @var
@@ -125,10 +120,10 @@ class GenerateCommand extends Command
      */
     protected function getOptions()
     {
-        return array(
-            array('dir', 'D', InputOption::VALUE_OPTIONAL, 'The model directory', array($this->dir)),
-            array('force', 'F', InputOption::VALUE_NONE, 'Overwrite any existing model factory'),
-        );
+        return [
+            ['dir', 'D', InputOption::VALUE_OPTIONAL, 'The model directory', $this->dir],
+            ['force', 'F', InputOption::VALUE_NONE, 'Overwrite any existing model factory'],
+        ];
     }
 
     protected function generateFactory($model)

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -291,11 +291,8 @@ class GenerateCommand extends Command
                             if ($relationObj instanceof Relation) {
                                 $relatedModel = '\\' . get_class($relationObj->getRelated());
                                 $relatedObj = new $relatedModel;
-
-                                $property = $relationObj->getForeignKey();
-                                $this->setProperty($property,'function () {
-             return factory('.get_class($relationObj->getRelated()).'::class)->create()->'.$relatedObj->getKeyName().';
-        }');
+                                $property = $relationObj->getForeignKeyName();
+                                $this->setProperty($property, 'factory(' . get_class($relationObj->getRelated()) . '::class)->create()->' . $relatedObj->getKeyName());
                             }
                         }
                     }
@@ -362,7 +359,7 @@ class GenerateCommand extends Command
             'user_name' => '$faker->userName',
             'password' => 'bcrypt($faker->password)',
             'url' => '$faker->url',
-            'remember_token' => 'str_random(10)',
+            'remember_token' => 'Str::random(10)',
             'uuid' => '$faker->uuid',
             'guid' => '$faker->uuid',
         ];

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -22,7 +22,7 @@ class GenerateCommand extends Command
      *
      * @var string
      */
-    protected $name = 'test-factory-helper:generate';
+    protected $name = 'generate:model-factory';
 
     /**
      * @var string

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -337,6 +337,7 @@ class GenerateCommand extends Command
             'username' => '$faker->userName',
             'user_name' => '$faker->userName',
             'password' => 'bcrypt($faker->password)',
+            'slug' => '$faker->slug',
             'url' => '$faker->url',
             'remember_token' => 'Str::random(10)',
             'uuid' => '$faker->uuid',

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -3,14 +3,13 @@
 namespace Mpociot\LaravelTestFactoryHelper\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\ClassLoader\ClassMapGenerator;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class GenerateCommand extends Command
 {
@@ -25,11 +24,6 @@ class GenerateCommand extends Command
      * @var string
      */
     protected $name = 'test-factory-helper:generate';
-
-    /**
-     * @var string
-     */
-    protected $filename = 'database/factories/ModelFactory.php';
 
     /**
      * @var string
@@ -64,7 +58,7 @@ class GenerateCommand extends Command
     /**
      * @var
      */
-    protected $reset;
+    protected $force;
 
     /**
      * @param Filesystem $files
@@ -83,25 +77,32 @@ class GenerateCommand extends Command
      */
     public function handle()
     {
-        $filename = $this->option('filename');
-        $this->dirs = $this->option('dir');
-        $model = $this->argument('model');
-        $ignore = $this->option('ignore');
-        $this->reset = $this->option('reset');
+        $this->dir = $this->option('dir');
+        $this->force = $this->option('force');
 
-        try {
-            $this->existingFactories = $this->files->get($filename);
-        } catch (FileNotFoundException $e) {
-            $this->existingFactories = '';
-        }
+        $models = $this->loadModels($this->argument('model'));
 
-        $result = $this->generateFactories($model, $ignore);
+        foreach ($models as $model) {
+            $filename = 'database/factories/' . class_basename($model) . 'Factory.php';
 
-        $written = $this->files->put('database/factories/ModelFactory.php', $result);
-        if ($written !== false) {
-            $this->info("Model factories were written successfully to ".$filename);
-        } else {
-            $this->error("Failed to write model factories to ".$filename);
+            if ($this->files->exists($filename) && !$this->force) {
+                $this->warn('Model factory exists, use --force to overwrite: ' . $filename);
+
+                continue;
+            }
+
+            $result = $this->generateFactory($model);
+
+            if ($result === false) {
+                continue;
+            }
+
+            $written = $this->files->put($filename, $result);
+            if ($written !== false) {
+                $this->info('Model factory created: ' . $filename);
+            } else {
+                $this->error('Failed to create model factory: ' . $filename);
+            }
         }
     }
 
@@ -126,92 +127,77 @@ class GenerateCommand extends Command
     protected function getOptions()
     {
         return array(
-            array('filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the model factory file', $this->filename),
-            array('dir', 'D', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The model dir', array($this->dir)),
-            array('reset', 'R', InputOption::VALUE_NONE, 'Remove the original ModelFactory instead of appending'),
-            array('ignore', 'I', InputOption::VALUE_OPTIONAL, 'Which models to ignore', ''),
+            array('dir', 'D', InputOption::VALUE_OPTIONAL, 'The model directory', array($this->dir)),
+            array('force', 'F', InputOption::VALUE_NONE, 'Overwrite any existing model factory'),
         );
     }
 
-    protected function generateFactories($loadModels, $ignore = '')
+    protected function generateFactory($model)
     {
+        $output = '<?php' . "\n\n";
 
-        if (empty($loadModels)) {
-            $models = $this->loadModels();
-        } else {
-            $models = array();
-            foreach ($loadModels as $model) {
-                $models = array_merge($models, explode(',', $model));
+        $this->properties = [];
+        if (!class_exists($model)) {
+            if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+                $this->error("Unable to find '$model' class");
             }
+            return false;
         }
 
-        $output = ($this->reset || !$this->files->exists('database/factories/ModelFactory.php')) ? '<?php'."\n\n" : $this->existingFactories;
-        $ignore = explode(',', $ignore);
+        try {
+            // handle abstract classes, interfaces, ...
+            $reflectionClass = new \ReflectionClass($model);
 
-        foreach ($models as $name) {
-            if (in_array($name, $ignore)) {
-                if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
-                    $this->comment("Ignoring model '$name'");
-                }
-                continue;
+            if (!$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Model')) {
+                return false;
             }
 
-            $this->properties = array();
-            if (class_exists($name)) {
-                try {
-                    // handle abstract classes, interfaces, ...
-                    $reflectionClass = new \ReflectionClass($name);
-
-                    if (!$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Model')) {
-                        continue;
-                    }
-
-                    if (!$this->reset && preg_match("/\\\$factory->define\((.*?)".preg_quote($reflectionClass->getName())."::class(.*?),/", $this->existingFactories)) {
-                        if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
-                            $this->error("Model '$name' already has a factory");
-                        }
-                        continue;
-                    }
-
-                    if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
-                        $this->comment("Loading model '$name'");
-                    }
-
-                    if (!$reflectionClass->IsInstantiable()) {
-                        // ignore abstract class or interface
-                        continue;
-                    }
-
-                    $model = $this->laravel->make($name);
-
-                    $this->getPropertiesFromTable($model);
-
-                    $this->getPropertiesFromMethods($model);
-
-                    $output .= $this->createFactory($name);
-                    $ignore[] = $name;
-                } catch (\Exception $e) {
-                    $this->error("Exception: " . $e->getMessage() . "\nCould not analyze class $name.");
-                }
+            if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+                $this->comment("Loading model '$model'");
             }
 
+            if (!$reflectionClass->IsInstantiable()) {
+                // ignore abstract class or interface
+                return false;
+            }
+
+            $model = $this->laravel->make($model);
+
+            $this->getPropertiesFromTable($model);
+            $this->getPropertiesFromMethods($model);
+
+            $output .= $this->createFactory($model);
+        } catch (\Exception $e) {
+            $this->error("Exception: " . $e->getMessage() . "\nCould not analyze class $model.");
         }
+
         return $output;
     }
 
 
-    protected function loadModels()
+    protected function loadModels($models = [])
     {
-        $models = array();
-        foreach ($this->dirs as $dir) {
-            $dir = base_path() . '/' . $dir;
-            if (file_exists($dir)) {
-                foreach (ClassMapGenerator::createMap($dir) as $model => $path) {
-                    $models[] = $model;
+        if (!empty($models)) {
+            return array_map(function ($name) {
+                if (strpos($name, '\\') !== false) {
+                    return $name;
                 }
-            }
+
+                return str_replace(
+                    [DIRECTORY_SEPARATOR, basename($this->laravel->path()) . '\\'],
+                    ['\\', $this->laravel->getNamespace()],
+                    $this->dir . DIRECTORY_SEPARATOR . $name
+                );
+            }, $models);
         }
-        return $models;
+
+
+        $dir = base_path($this->dir);
+        if (!file_exists($dir)) {
+            return [];
+        }
+
+        return array_keys(ClassMapGenerator::createMap($dir));
     }
 
     /**
@@ -251,7 +237,7 @@ class GenerateCommand extends Command
                     $name !== $model::CREATED_AT &&
                     $name !== $model::UPDATED_AT
                 ) {
-                    if(!method_exists($model,'getDeletedAtColumn') || (method_exists($model,'getDeletedAtColumn') && $name !== $model->getDeletedAtColumn())) {
+                    if (!method_exists($model, 'getDeletedAtColumn') || (method_exists($model, 'getDeletedAtColumn') && $name !== $model->getDeletedAtColumn())) {
                         $this->setProperty($name, $type);
                     }
                 }
@@ -307,17 +293,10 @@ class GenerateCommand extends Command
      */
     protected function setProperty($name, $type = null)
     {
-        if (!isset($this->properties[$name])) {
-            $this->properties[$name] = array();
-            $this->properties[$name]['type'] = 'mixed';
-            $this->properties[$name]['faker'] = false;
-        }
-        if ($type !== null) {
-            $this->properties[$name]['type'] = $type;
-        }
+        if ($type !== null && Str::startsWith($type, 'factory(')) {
+            $this->properties[$name] = $type;
 
-        if (Str::startsWith($type,'function ()')) {
-            $this->properties[$name]['faker'] = true;
+            return;
         }
 
         $fakeableTypes = [
@@ -365,13 +344,11 @@ class GenerateCommand extends Command
         ];
 
         if (isset($fakeableNames[$name])) {
-            $this->properties[$name]['faker'] = true;
-            $this->properties[$name]['type'] = $fakeableNames[$name];
+            $this->properties[$name] = $fakeableNames[$name];
         }
 
-        if (isset($fakeableTypes[$type]) && !$this->properties[$name]['faker']) {
-            $this->properties[$name]['faker'] = true;
-            $this->properties[$name]['type'] = $fakeableTypes[$type];
+        if (isset($fakeableTypes[$type])) {
+            $this->properties[$name] = $fakeableTypes[$type];
         }
     }
 

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -6,7 +6,6 @@ use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
-use Symfony\Component\ClassLoader\ClassMapGenerator;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -197,7 +196,13 @@ class GenerateCommand extends Command
             return [];
         }
 
-        return array_keys(ClassMapGenerator::createMap($dir));
+        return array_map(function (\SplFIleInfo $file) {
+            return str_replace(
+                [DIRECTORY_SEPARATOR, basename($this->laravel->path()) . '\\'],
+                ['\\', $this->laravel->getNamespace()],
+                $file->getPath() . DIRECTORY_SEPARATOR . basename($file->getFilename(), '.php')
+            );
+        }, $this->files->allFiles($this->dir));
     }
 
     /**


### PR DESCRIPTION
Several changes in this, hope you don't mind. Mainly, set the minimum requirement of Laravel 5.5. This allowed removal of PHP < 7 syntax, old references and helpers, and deprecated Symfony methods.

Also did a general scouting of the code which lead to removal of not-so-often used options to help focus the commands purpose.

Finally a rename to provide symmetry with `generate` commands offered in other packages.