### PR TITLE
Fix for Laravel < 5.8 Exception: Call to undefined method BelongsTo::getForeignKeyName()

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -277,7 +277,9 @@ class GenerateCommand extends Command
                             if ($relationObj instanceof Relation) {
                                 $relatedModel = '\\' . get_class($relationObj->getRelated());
                                 $relatedObj = new $relatedModel;
-                                $property = $relationObj->getForeignKeyName();
+                                $property = property_exists($relationObj, 'getForeignKeyName')
+                                    ? $relationObj->getForeignKeyName()
+                                    : $relationObj->getForeignKey();
                                 $this->setProperty($property, 'factory(' . get_class($relationObj->getRelated()) . '::class)->create()->' . $relatedObj->getKeyName());
                             }
                         }


### PR DESCRIPTION
Because of changes in Laravel 5.8,  `getOwnerKey` methods of the  `BelongsTo` relationship have been renamed to `getForeignKeyName`.