### PR TITLE
Fix for getForeignKey() exception on Laravel > 5.8

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -277,7 +277,7 @@ class GenerateCommand extends Command
                         if ($relationObj instanceof Relation) {
                             $relatedModel = '\\' . get_class($relationObj->getRelated());
                             $relatedObj = new $relatedModel;
-                            $property = property_exists($relationObj, 'getForeignKeyName')
+                            $property = method_exists($relationObj, 'getForeignKeyName')
                                 ? $relationObj->getForeignKeyName()
                                 : $relationObj->getForeignKey();
                             $this->setProperty($property, 'factory(' . get_class($relationObj->getRelated()) . '::class)->create()->' . $relatedObj->getKeyName());


### PR DESCRIPTION
Fix for exception: `Exception: Call to undefined method Illuminate\Database\Eloquent\Relations\BelongsTo::getForeignKey()` on Laravel >= 5.8 while still maintaining backwards compatibility with Laravel < 5.8