### PR TITLE
Allow override relations columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $factory->define(App\User::class, function (Faker\Generator $faker) {
         'username' => $faker->userName,
         'email' => $faker->safeEmail,
         'password' => bcrypt($faker->password),
-        'company_id' => factory(App\Company::class)->create()->id,
+        'company_id' => factory(App\Company::class),
         'remember_token' => Str::random(10),
     ];
 });

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -280,7 +280,7 @@ class GenerateCommand extends Command
                             $property = method_exists($relationObj, 'getForeignKeyName')
                                 ? $relationObj->getForeignKeyName()
                                 : $relationObj->getForeignKey();
-                            $this->setProperty($property, 'factory(' . get_class($relationObj->getRelated()) . '::class)->create()->' . $relatedObj->getKeyName());
+                            $this->setProperty($property, 'factory(' . get_class($relationObj->getRelated()) . '::class)');
                         }
                     }
                 }


### PR DESCRIPTION
It allows to override value without creating another model instance.
It works like a closure
```
'user_id' => function () {
            return factory(App\User::class)->create()->id;
        }
```