### PR TITLE
Fix related model bug + tweak output

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -80,7 +80,7 @@ class GenerateCommand extends Command
             $filename = 'database/factories/' . class_basename($model) . 'Factory.php';
 
             if ($this->files->exists($filename) && !$this->force) {
-                $this->warn('Model factory exists, use --force to overwrite: ' . $filename);
+                $this->line('<fg=yellow>Model factory exists, use --force to overwrite:</fg=yellow> ' . $filename);
 
                 continue;
             }
@@ -93,9 +93,9 @@ class GenerateCommand extends Command
 
             $written = $this->files->put($filename, $result);
             if ($written !== false) {
-                $this->info('Model factory created: ' . $filename);
+                $this->line('<info>Model factory created:</info> ' . $filename);
             } else {
-                $this->error('Failed to create model factory: ' . $filename);
+                $this->line('<error>Failed to create model factory:</error> ' . $filename);
             }
         }
     }

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -280,7 +280,9 @@ class GenerateCommand extends Command
                             $property = method_exists($relationObj, 'getForeignKeyName')
                                 ? $relationObj->getForeignKeyName()
                                 : $relationObj->getForeignKey();
-                            $this->setProperty($property, 'factory(' . get_class($relationObj->getRelated()) . '::class)->create()->' . $relatedObj->getKeyName());
+                            $this->setProperty($property, 'function () {
+            return factory(' . get_class($relationObj->getRelated()) . '::class)->create()->' . $relatedObj->getKeyName() . ';
+        }');
                         }
                     }
                 }
@@ -294,7 +296,7 @@ class GenerateCommand extends Command
      */
     protected function setProperty($name, $type = null)
     {
-        if ($type !== null && Str::startsWith($type, 'factory(')) {
+        if ($type !== null && Str::startsWith($type, 'function (')) {
             $this->properties[$name] = $type;
 
             return;


### PR DESCRIPTION
This fixes a bug with the creation of related models as reported in #37 and #38 with the corresponding change within the `setProperty` method.

Also snuck in a small tweak to the console output to more closely match the coloring used by artisan `make` commands.