### PR TITLE
Update dependencies for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "require": {
         "php": ">=7.0",
-        "illuminate/support": "^5.5",
-        "illuminate/console": "^5.5",
-        "illuminate/filesystem": "^5.5",
+        "illuminate/support": "^5.5|^6.0",
+        "illuminate/console": "^5.5|^6.0",
+        "illuminate/filesystem": "^5.5|^6.0",
         "doctrine/dbal": "~2.3"
     },
     "autoload": {


### PR DESCRIPTION
There's more than one way to require Laravel 6, but this one should suffice.