### PR TITLE
Allow "enum" type

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -2,15 +2,17 @@
 
 namespace Mpociot\LaravelTestFactoryHelper\Console;
 
+use Doctrine\DBAL\Types\Type;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Mpociot\LaravelTestFactoryHelper\Types\EnumType;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Doctrine\DBAL\Types\Type;
-use Illuminate\Support\Facades\DB;
+
 
 class GenerateCommand extends Command
 {
@@ -73,7 +75,7 @@ class GenerateCommand extends Command
      */
     public function handle()
     {
-        Type::addType('customEnum', \Mpociot\LaravelTestFactoryHelper\Types\EnumType::class);
+        Type::addType('customEnum', EnumType::class);
         $this->dir = $this->option('dir');
         $this->force = $this->option('force');
 

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class GenerateCommand extends Command
 {
+
     /**
      * @var Filesystem $files
      */
@@ -47,7 +48,7 @@ class GenerateCommand extends Command
     /**
      * @var array
      */
-    protected $properties = array();
+    protected $properties = [];
 
     /**
      * @var
@@ -61,7 +62,7 @@ class GenerateCommand extends Command
     {
         parent::__construct();
         $this->files = $files;
-        $this->view = $view;
+        $this->view  = $view;
     }
 
     /**
@@ -71,7 +72,7 @@ class GenerateCommand extends Command
      */
     public function handle()
     {
-        $this->dir = $this->option('dir');
+        $this->dir   = $this->option('dir');
         $this->force = $this->option('force');
 
         $models = $this->loadModels($this->argument('model'));
@@ -79,7 +80,7 @@ class GenerateCommand extends Command
         foreach ($models as $model) {
             $filename = 'database/factories/' . class_basename($model) . 'Factory.php';
 
-            if ($this->files->exists($filename) && !$this->force) {
+            if ($this->files->exists($filename) && ! $this->force) {
                 $this->line('<fg=yellow>Model factory exists, use --force to overwrite:</fg=yellow> ' . $filename);
 
                 continue;
@@ -108,9 +109,9 @@ class GenerateCommand extends Command
      */
     protected function getArguments()
     {
-        return array(
-            array('model', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Which models to include', array()),
-        );
+        return [
+            ['model', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Which models to include', []],
+        ];
     }
 
     /**
@@ -131,10 +132,11 @@ class GenerateCommand extends Command
         $output = '<?php' . "\n\n";
 
         $this->properties = [];
-        if (!class_exists($model)) {
+        if ( ! class_exists($model)) {
             if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
                 $this->error("Unable to find '$model' class");
             }
+
             return false;
         }
 
@@ -142,7 +144,7 @@ class GenerateCommand extends Command
             // handle abstract classes, interfaces, ...
             $reflectionClass = new \ReflectionClass($model);
 
-            if (!$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Model')) {
+            if ( ! $reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Model')) {
                 return false;
             }
 
@@ -150,7 +152,7 @@ class GenerateCommand extends Command
                 $this->comment("Loading model '$model'");
             }
 
-            if (!$reflectionClass->IsInstantiable()) {
+            if ( ! $reflectionClass->IsInstantiable()) {
                 // ignore abstract class or interface
                 return false;
             }
@@ -171,7 +173,7 @@ class GenerateCommand extends Command
 
     protected function loadModels($models = [])
     {
-        if (!empty($models)) {
+        if ( ! empty($models)) {
             return array_map(function ($name) {
                 if (strpos($name, '\\') !== false) {
                     return $name;
@@ -187,7 +189,7 @@ class GenerateCommand extends Command
 
 
         $dir = base_path($this->dir);
-        if (!file_exists($dir)) {
+        if ( ! file_exists($dir)) {
             return [];
         }
 
@@ -207,13 +209,15 @@ class GenerateCommand extends Command
      */
     protected function getPropertiesFromTable($model)
     {
-        $table = $model->getConnection()->getTablePrefix() . $model->getTable();
-        $schema = $model->getConnection()->getDoctrineSchemaManager($table);
+        $table            = $model->getConnection()->getTablePrefix() . $model->getTable();
+        $schema           = $model->getConnection()->getDoctrineSchemaManager($table);
         $databasePlatform = $schema->getDatabasePlatform();
-        $databasePlatform->registerDoctrineTypeMapping('enum', 'string');
+
+        \Doctrine\DBAL\Types\Type::addType("customEnum", "Mpociot\LaravelTestFactoryHelper\Types\EnumType");
+        $databasePlatform->registerDoctrineTypeMapping('enum', 'customEnum');
 
         $platformName = $databasePlatform->getName();
-        $customTypes = $this->laravel['config']->get("ide-helper.custom_db_types.{$platformName}", array());
+        $customTypes  = $this->laravel['config']->get("ide-helper.custom_db_types.{$platformName}", []);
         foreach ($customTypes as $yourTypeName => $doctrineTypeName) {
             $databasePlatform->registerDoctrineTypeMapping($yourTypeName, $doctrineTypeName);
         }
@@ -233,12 +237,13 @@ class GenerateCommand extends Command
                 } else {
                     $type = $column->getType()->getName();
                 }
-                if (!($model->incrementing && $model->getKeyName() === $name) &&
-                    $name !== $model::CREATED_AT &&
-                    $name !== $model::UPDATED_AT
+                if ( ! ($model->incrementing && $model->getKeyName() === $name) &&
+                     $name !== $model::CREATED_AT &&
+                     $name !== $model::UPDATED_AT
                 ) {
-                    if (!method_exists($model, 'getDeletedAtColumn') || (method_exists($model, 'getDeletedAtColumn') && $name !== $model->getDeletedAtColumn())) {
-                        $this->setProperty($name, $type);
+                    if ( ! method_exists($model, 'getDeletedAtColumn') ||
+                         (method_exists($model, 'getDeletedAtColumn') && $name !== $model->getDeletedAtColumn())) {
+                        $this->setProperty($table, $name, $type, $model);
                     }
                 }
             }
@@ -252,35 +257,36 @@ class GenerateCommand extends Command
     protected function getPropertiesFromMethods($model)
     {
         $methods = get_class_methods($model);
+        $table   = $model->getConnection()->getTablePrefix() . $model->getTable();
 
         foreach ($methods as $method) {
-            if (!method_exists('Illuminate\Database\Eloquent\Model', $method) && !Str::startsWith($method, 'get')) {
+            if ( ! method_exists('Illuminate\Database\Eloquent\Model', $method) && ! Str::startsWith($method, 'get')) {
                 //Use reflection to inspect the code, based on Illuminate/Support/SerializableClosure.php
                 $reflection = new \ReflectionMethod($model, $method);
-                $file = new \SplFileObject($reflection->getFileName());
+                $file       = new \SplFileObject($reflection->getFileName());
                 $file->seek($reflection->getStartLine() - 1);
                 $code = '';
                 while ($file->key() < $reflection->getEndLine()) {
                     $code .= $file->current();
                     $file->next();
                 }
-                $code = trim(preg_replace('/\s\s+/', '', $code));
+                $code  = trim(preg_replace('/\s\s+/', '', $code));
                 $begin = strpos($code, 'function(');
-                $code = substr($code, $begin, strrpos($code, '}') - $begin + 1);
-                foreach (array(
+                $code  = substr($code, $begin, strrpos($code, '}') - $begin + 1);
+                foreach ([
                              'belongsTo',
-                         ) as $relation) {
+                         ] as $relation) {
                     $search = '$this->' . $relation . '(';
                     if ($pos = stripos($code, $search)) {
                         //Resolve the relation's model to a Relation object.
                         $relationObj = $model->$method();
                         if ($relationObj instanceof Relation) {
                             $relatedModel = '\\' . get_class($relationObj->getRelated());
-                            $relatedObj = new $relatedModel;
-                            $property = method_exists($relationObj, 'getForeignKeyName')
+                            $relatedObj   = new $relatedModel;
+                            $property     = method_exists($relationObj, 'getForeignKeyName')
                                 ? $relationObj->getForeignKeyName()
                                 : $relationObj->getForeignKey();
-                            $this->setProperty($property, 'function () {
+                            $this->setProperty($table, $property, 'function () {
             return factory(' . get_class($relationObj->getRelated()) . '::class)->create()->' . $relatedObj->getKeyName() . ';
         }');
                         }
@@ -291,10 +297,11 @@ class GenerateCommand extends Command
     }
 
     /**
-     * @param string $name
+     * @param string      $table
+     * @param string      $name
      * @param string|null $type
      */
-    protected function setProperty($name, $type = null)
+    protected function setProperty($table, $name, $type = null)
     {
         if ($type !== null && Str::startsWith($type, 'function (')) {
             $this->properties[$name] = $type;
@@ -303,53 +310,54 @@ class GenerateCommand extends Command
         }
 
         $fakeableTypes = [
-            'string' => '$faker->word',
-            'text' => '$faker->text',
-            'date' => '$faker->date()',
-            'time' => '$faker->time()',
-            'guid' => '$faker->word',
+            'string'     => '$faker->word',
+            'enum'       => '$faker->randomElement(' . $this->enumValues($table, $name) . ')',
+            'text'       => '$faker->text',
+            'date'       => '$faker->date()',
+            'time'       => '$faker->time()',
+            'guid'       => '$faker->word',
             'datetimetz' => '$faker->dateTime()',
-            'datetime' => '$faker->dateTime()',
-            'integer' => '$faker->randomNumber()',
-            'bigint' => '$faker->randomNumber()',
-            'smallint' => '$faker->randomNumber()',
-            'decimal' => '$faker->randomFloat()',
-            'float' => '$faker->randomFloat()',
-            'boolean' => '$faker->boolean'
+            'datetime'   => '$faker->dateTime()',
+            'integer'    => '$faker->randomNumber()',
+            'bigint'     => '$faker->randomNumber()',
+            'smallint'   => '$faker->randomNumber()',
+            'decimal'    => '$faker->randomFloat()',
+            'float'      => '$faker->randomFloat()',
+            'boolean'    => '$faker->boolean',
         ];
 
         $fakeableNames = [
-            'city' => '$faker->city',
-            'company' => '$faker->company',
-            'country' => '$faker->country',
-            'description' => '$faker->text',
-            'email' => '$faker->safeEmail',
-            'first_name' => '$faker->firstName',
-            'firstname' => '$faker->firstName',
-            'guid' => '$faker->uuid',
-            'last_name' => '$faker->lastName',
-            'lastname' => '$faker->lastName',
-            'lat' => '$faker->latitude',
-            'latitude' => '$faker->latitude',
-            'lng' => '$faker->longitude',
-            'longitude' => '$faker->longitude',
-            'name' => '$faker->name',
-            'password' => 'bcrypt($faker->password)',
-            'phone' => '$faker->phoneNumber',
-            'phone_number' => '$faker->phoneNumber',
-            'postcode' => '$faker->postcode',
-            'postal_code' => '$faker->postcode',
+            'city'           => '$faker->city',
+            'company'        => '$faker->company',
+            'country'        => '$faker->country',
+            'description'    => '$faker->text',
+            'email'          => '$faker->safeEmail',
+            'first_name'     => '$faker->firstName',
+            'firstname'      => '$faker->firstName',
+            'guid'           => '$faker->uuid',
+            'last_name'      => '$faker->lastName',
+            'lastname'       => '$faker->lastName',
+            'lat'            => '$faker->latitude',
+            'latitude'       => '$faker->latitude',
+            'lng'            => '$faker->longitude',
+            'longitude'      => '$faker->longitude',
+            'name'           => '$faker->name',
+            'password'       => 'bcrypt($faker->password)',
+            'phone'          => '$faker->phoneNumber',
+            'phone_number'   => '$faker->phoneNumber',
+            'postcode'       => '$faker->postcode',
+            'postal_code'    => '$faker->postcode',
             'remember_token' => 'Str::random(10)',
-            'slug' => '$faker->slug',
-            'street' => '$faker->streetName',
-            'address1' => '$faker->streetAddress',
-            'address2' => '$faker->secondaryAddress',
-            'summary' => '$faker->text',
-            'url' => '$faker->url',
-            'user_name' => '$faker->userName',
-            'username' => '$faker->userName',
-            'uuid' => '$faker->uuid',
-            'zip' => '$faker->postcode',
+            'slug'           => '$faker->slug',
+            'street'         => '$faker->streetName',
+            'address1'       => '$faker->streetAddress',
+            'address2'       => '$faker->secondaryAddress',
+            'summary'        => '$faker->text',
+            'url'            => '$faker->url',
+            'user_name'      => '$faker->userName',
+            'username'       => '$faker->userName',
+            'uuid'           => '$faker->uuid',
+            'zip'            => '$faker->postcode',
         ];
 
         if (isset($fakeableNames[$name])) {
@@ -367,6 +375,16 @@ class GenerateCommand extends Command
         $this->properties[$name] = '$faker->word';
     }
 
+    public static function enumValues($table, $name)
+    {
+        $type = \Illuminate\Support\Facades\DB::select(\Illuminate\Support\Facades\DB::raw(
+            'SHOW COLUMNS FROM ' . $table . ' WHERE Field = "' . $name . '"'))[0]->Type;
+        preg_match_all("/'([^']+)'/", $type, $matches);
+
+        $values = isset($matches[1]) ? $matches[1] : [];
+
+        return "['" . implode("','", $values) . "']";
+    }
 
     /**
      * @param string $class

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -72,6 +72,7 @@ class GenerateCommand extends Command
      */
     public function handle()
     {
+        \Doctrine\DBAL\Types\Type::addType("customEnum", "Mpociot\LaravelTestFactoryHelper\Types\EnumType");
         $this->dir   = $this->option('dir');
         $this->force = $this->option('force');
 
@@ -213,7 +214,6 @@ class GenerateCommand extends Command
         $schema           = $model->getConnection()->getDoctrineSchemaManager($table);
         $databasePlatform = $schema->getDatabasePlatform();
 
-        \Doctrine\DBAL\Types\Type::addType("customEnum", "Mpociot\LaravelTestFactoryHelper\Types\EnumType");
         $databasePlatform->registerDoctrineTypeMapping('enum', 'customEnum');
 
         $platformName = $databasePlatform->getName();

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -73,7 +73,7 @@ class GenerateCommand extends Command
      */
     public function handle()
     {
-        Type::addType("customEnum", "Mpociot\LaravelTestFactoryHelper\Types\EnumType");
+        Type::addType('customEnum', \Mpociot\LaravelTestFactoryHelper\Types\EnumType::class);
         $this->dir = $this->option('dir');
         $this->force = $this->option('force');
 
@@ -306,7 +306,7 @@ class GenerateCommand extends Command
         }
 
         $fakeableTypes = [
-						'enum' => '$faker->randomElement(' . $this->enumValues($table, $name) . ')',
+	    'enum' => '$faker->randomElement(' . $this->enumValues($table, $name) . ')',
             'string' => '$faker->word',
             'text' => '$faker->text',
             'date' => '$faker->date()',

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -71,7 +71,7 @@ class GenerateCommand extends Command
      */
     public function handle()
     {
-			  \Doctrine\DBAL\Types\Type::addType("customEnum", "Mpociot\LaravelTestFactoryHelper\Types\EnumType");
+        \Doctrine\DBAL\Types\Type::addType("customEnum", "Mpociot\LaravelTestFactoryHelper\Types\EnumType");
         $this->dir = $this->option('dir');
         $this->force = $this->option('force');
 
@@ -253,7 +253,7 @@ class GenerateCommand extends Command
     protected function getPropertiesFromMethods($model)
     {
         $methods = get_class_methods($model);
-				$table   = $model->getConnection()->getTablePrefix() . $model->getTable();
+        $table   = $model->getConnection()->getTablePrefix() . $model->getTable();
 
         foreach ($methods as $method) {
             if (!method_exists('Illuminate\Database\Eloquent\Model', $method) && !Str::startsWith($method, 'get')) {
@@ -369,11 +369,12 @@ class GenerateCommand extends Command
 
         $this->properties[$name] = '$faker->word';
     }
-		
+
 		public static function enumValues($table, $name)
     {
-        $type = \Illuminate\Support\Facades\DB::select(\Illuminate\Support\Facades\DB::raw(
-            'SHOW COLUMNS FROM ' . $table . ' WHERE Field = "' . $name . '"'))[0]->Type;
+        $dbRaw = \Illuminate\Support\Facades\DB::raw('SHOW COLUMNS FROM ' . $table . ' WHERE Field = "' . $name . '"');
+        $type = \Illuminate\Support\Facades\DB::select($dbRaw)[0]->Type;
+
         preg_match_all("/'([^']+)'/", $type, $matches);
 
         $values = isset($matches[1]) ? $matches[1] : [];

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -306,7 +306,7 @@ class GenerateCommand extends Command
         }
 
         $fakeableTypes = [
-	    'enum' => '$faker->randomElement(' . $this->enumValues($table, $name) . ')',
+            'enum' => '$faker->randomElement(' . $this->enumValues($table, $name) . ')',
             'string' => '$faker->word',
             'text' => '$faker->text',
             'date' => '$faker->date()',

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Doctrine\DBAL\Types\Type;
+use Illuminate\Support\Facades\DB;
 
 class GenerateCommand extends Command
 {
@@ -71,7 +73,7 @@ class GenerateCommand extends Command
      */
     public function handle()
     {
-        \Doctrine\DBAL\Types\Type::addType("customEnum", "Mpociot\LaravelTestFactoryHelper\Types\EnumType");
+        Type::addType("customEnum", "Mpociot\LaravelTestFactoryHelper\Types\EnumType");
         $this->dir = $this->option('dir');
         $this->force = $this->option('force');
 
@@ -370,14 +372,13 @@ class GenerateCommand extends Command
         $this->properties[$name] = '$faker->word';
     }
 
-		public static function enumValues($table, $name)
+    public static function enumValues($table, $name)
     {
-        $dbRaw = \Illuminate\Support\Facades\DB::raw('SHOW COLUMNS FROM ' . $table . ' WHERE Field = "' . $name . '"');
-        $type = \Illuminate\Support\Facades\DB::select($dbRaw)[0]->Type;
+        $type = DB::select(DB::raw('SHOW COLUMNS FROM ' . $table . ' WHERE Field = "' . $name . '"'))[0]->Type;
 
         preg_match_all("/'([^']+)'/", $type, $matches);
 
-        $values = isset($matches[1]) ? $matches[1] : [];
+        $values = isset($matches[1]) ? $matches[1] : array();
 
         return "['" . implode("','", $values) . "']";
     }

--- a/src/Types/EnumType.php
+++ b/src/Types/EnumType.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Mpociot\LaravelTestFactoryHelper\Types;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/**
+ * My custom datatype.
+ */
+class EnumType extends Type
+{
+
+    const ENUM = 'enum'; // modify to match your type name
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        // this is wrong, but it also isn't important, since we're not modifying tables anyways. (this method must exist to match the abstract parent class, but we won't use it)
+        return 'ENUM';
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        return $value;
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        return $value;
+    }
+
+    public function getName()
+    {
+        return self::ENUM;
+    }
+}

--- a/src/Types/EnumType.php
+++ b/src/Types/EnumType.php
@@ -5,17 +5,20 @@ namespace Mpociot\LaravelTestFactoryHelper\Types;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
-/**
- * My custom datatype.
- */
 class EnumType extends Type
 {
 
-    const ENUM = 'enum'; // modify to match your type name
+    const ENUM = 'enum';
 
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
-        // this is wrong, but it also isn't important, since we're not modifying tables anyways. (this method must exist to match the abstract parent class, but we won't use it)
+        /* 
+         * This is wrong, but it also isn't important, since we're not modifying
+         * tables anyways. This method must exist to match the abstract parent
+         * class, but we won't use it. Normally, this should return the SQL 
+         * required to create an 'enum' column, but since this function doesn't
+         * know the values of the enum field, that's not possible.
+         */
         return 'ENUM';
     }
 


### PR DESCRIPTION
Instead of just mapping enum type fields to act as "string", I created a custom type. This way a MySQL field like this:
```
size ENUM('x-small', 'small', 'medium', 'large', 'x-large')
```

will produce a factory like this:

```
...
'size' => $faker->randomElement(['x-small','small','medium','large','x-large']),
...
```