### PR TITLE
Require Laravel 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ $factory->define(App\User::class, function (Faker\Generator $faker) {
         'username' => $faker->userName,
         'email' => $faker->safeEmail,
         'password' => bcrypt($faker->password),
-        'company_id' => function () {
-            return factory(App\Company::class)->create()->id;
-        },
+        'company_id' => factory(App\Company::class),
         'remember_token' => Str::random(10),
     ];
 });

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "keywords": ["Laravel", "Tests", "Factory"],
     "license": "MIT",
     "require": {
-        "php": ">=7.0",
-        "illuminate/support": "^5.5|^6.0",
-        "illuminate/console": "^5.5|^6.0",
-        "illuminate/filesystem": "^5.5|^6.0",
-        "doctrine/dbal": "~2.3"
+        "php": "^7.2",
+        "illuminate/support": "^6.0",
+        "illuminate/console": "^6.0",
+        "illuminate/filesystem": "^6.0",
+        "doctrine/dbal": "^2.9"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
With all previous versions of Laravel reaching end of life and the upcoming release of Laravel 7, it's time to bump the dependencies and modernize the generated factory code using Laravel 6 as the new minimum Laravel version.