### PR TITLE
PostgreSQL query fix

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -13,7 +13,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-
 class GenerateCommand extends Command
 {
     /**
@@ -368,9 +367,11 @@ class GenerateCommand extends Command
         if ($table === null) {
             return "[]";
         }
-
-        $type = DB::select(DB::raw('SHOW COLUMNS FROM ' . $table . ' WHERE Field = "' . $name . '"'))[0]->Type;
-
+        if (env('DB_HOST') == 'postgres') {
+            $type = DB::select(DB::raw('SELECT column_name,data_type FROM information_schema.columns WHERE table_name = \'' . $table . '\' AND column_name = \'' . $name . '\''))[0]->data_type;
+        } else {
+            $type = DB::select(DB::raw('SHOW COLUMNS FROM ' . $table . ' WHERE Field = "' . $name . '"'))[0]->Type;
+        }
         preg_match_all("/'([^']+)'/", $type, $matches);
 
         $values = isset($matches[1]) ? $matches[1] : array();
@@ -394,5 +395,4 @@ class GenerateCommand extends Command
 
         return $content;
     }
-
 }


### PR DESCRIPTION
If the application is connected to an postgres DB then the query that existed wouldn't suffice, because postgres has a different syntax. I added a simple if clause to check if the laravel application is connected to an postgres DB, if so the query will be executed with proper postgres syntax else the existing query will be executed. This will remove the SQL error as well as the class not recognized error when running the php artisan command for applications that have postgres DB.