### PR TITLE
Better support for enums.

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -391,7 +391,7 @@ class GenerateCommand extends Command
             $types = DB::connection($model->getConnectionName())
                 ->select(DB::raw("
                     select matches[1]
-                    from pg_constraint, regexp_matches(consrc, '''(.+?)''', 'g') matches
+                    from pg_constraint, regexp_matches(pg_get_constraintdef(\"oid\"), '''(.+?)''', 'g') matches
                     where contype = 'c'
                         and conname = '{$table}_{$name}_check'
                         and conrelid = 'public.{$table}'::regclass;


### PR DESCRIPTION
Fix proposed in #51 for issue #50 will remove SQL error, but also make enum fields always a `$faker->word` in generated factories.
PostgreSQL implementation of enum does not store allowed values in type definition, instead there is a field constraint.

I came up with solution that supports both MySQL and PostgreSQL.
Right now it should work even without a custom enum type for Doctrine.

I tested it with PostgreSQL and this migration:
```php
Schema::create('tests', function (Blueprint $table) {
    $table->bigIncrements('id');
    $table->enum('test', ['one', 'two', 'three']);
    $table->timestamps();
});            
```
Generated factory:
```php
$factory->define(App\Models\Test::class, function (Faker $faker) {
    return [
        'test' => $faker->randomElement(['one', 'two', 'three']),
    ];
});
```

Changes that were made:
- Model object is passed all the way to `enumValues` function to check connection driver name.
- Function `enumValues` is not static anymore (I honestly don't know why it was).
- Enum values parsing from field constraint for PostgreSQL has been implemented based on [this question on StackOverflow](https://stackoverflow.com/questions/47047207/how-can-i-get-a-list-of-allowed-values-for-a-postgres-constraint-check-from-php).
- Field mapped in `setProperty` is returned instantly if matches any of `$fakeableNames`, so it won't make a DB call for enum.
- Field is set to enum with `$faker->randomElement` if any enum values are present (only if it's an actual enum field in database).
